### PR TITLE
[B] Fix problem parsing space input

### DIFF
--- a/rps.sh
+++ b/rps.sh
@@ -7,4 +7,4 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-node $DIR/dist/main/index.js $@
+node $DIR/dist/main/index.js "$@"


### PR DESCRIPTION
Fix problem with spaces between quotes not being detected by yargs.

In:
`rps --description "This is a long description"`
The description would be parsed as "This"