### PR TITLE
[S] Updated the startDev cmd to fit new dir structure

### DIFF
--- a/templates/common/package.json
+++ b/templates/common/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "precommit": "npm run lint",
     "start": "node .",
-    "startDev": "nodemon --watch src/main --watch package.json -e ts,json -q -x 'rm -fr dist && echo \"\\n============\\nCOMPILING...\\n============\\n\\n\" && tsc --outDir dist || return 0 && node .'",
+    "startDev": "nodemon --watch src/ --watch package.json -e ts,json -q -x 'rm -fr dist && echo \"\\n============\\nCOMPILING...\\n============\\n\\n\" && tsc --outDir dist || return 0 && node .'",
     "make": "rm -fr dist && tsc",
     "lint": "tslint -c tslint.json src/**/*.ts",
     "test": "nyc --reporter lcov tape $(find dist -name '*.spec.js' ! -name 'index.js') | tap-spec",


### PR DESCRIPTION
The nodemon command in `startDev` was watching the wrong folder since we moved to a flatter structure.